### PR TITLE
image request: alter regex for fewer accidental triggers

### DIFF
--- a/functions.py
+++ b/functions.py
@@ -85,7 +85,7 @@ def check_for_image_request(user_message):
     user_message = user_message.lower()
     
     # Create a pattern we'll be matching against
-    pattern = re.compile('(send|create|give|generate|draw|snap|show|take|message).*?(image|picture|photo|drawing|screenshot)')
+    pattern = re.compile('\b(?:send|create|give|generate|draw|snap|show|take|message)\b.*?(?:image|picture|photo(?:graph)?|drawing|screenshot)s?\b')
     
     # Do some matching, I suppose
     result = bool(pattern.search(user_message))


### PR DESCRIPTION
This change amends the regex used for detecting image-generation requests to reduce the possibility of an accidental trigger phrase.

Previously, messages like "pleasedrawphoto" would trigger the image detection request - while it might be argued this is the intent, it seems neater to require an actual sentence structure. With this change to the regex the match needs at least a word boundary in between the "give" part and the "image" part, as well as before and after the whole phrase. It also allows "photograph" as an optional extension of "photo", and allows plurals in the "image" part (e.g. "photo"/"photos", "screenshot"/"screenshots").

Background:
Frog asked for a story https://discord.com/channels/701128987702984715/1091777251596587038/1209446105750966302 and happened to give a prompt that matched `take.*?photo`. The particular string was:

> photographs **take**n in playgrounds across western Canada between the years of 2012 and 2015. Later analysis has revealed that 75% of the people in **photo**graphs

This triggered the image check in spite of the prompt not intending it.

A further change here could be to exclude prompts that start with e.g. "tell me a story" or similar (such as `tell me a story about a person who likes to take pictures of clouds`) but I thought I'd raise the basic change first and discuss the deeper changes during review.